### PR TITLE
evaluate full name

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,3 +6,7 @@ indent-after-paren=2
 # Disable C0111 (docstrings) - use useful method names instead
 # Disable C0103 (invalid variable name) - in very short blocks it is okay to use generic names
 disable=C0111,C0103,W0108,E1101,C0330,C1801
+
+[TYPECHECK]
+extension-pkg-whitelist=lxml
+ignored-modules=six.moves

--- a/sciencebeam_judge/conftest.py
+++ b/sciencebeam_judge/conftest.py
@@ -1,0 +1,8 @@
+import logging
+
+import pytest
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_logging():
+  logging.root.handlers = []
+  logging.basicConfig(level='DEBUG')

--- a/sciencebeam_judge/default_xml_mapping_test.py
+++ b/sciencebeam_judge/default_xml_mapping_test.py
@@ -1,0 +1,26 @@
+from lxml import etree
+from lxml.builder import E
+
+def fn_jats_full_name(_, nodes):
+  print('nodes:', nodes)
+  return [
+    ' '.join([
+      n.text
+      for n in [node.find('given-names'), node.find('surname')]
+      if n is not None
+    ])
+    for node in nodes
+  ]
+
+class TestDefaultXmlMapping(object):
+  class TestAuthorNames(object):
+    def test_(self):
+      xml = E.article(
+        E.name(
+          E('given-names', 'Tom'),
+          E('surname', 'Thomson')
+        )
+      )
+      functionNS = etree.FunctionNamespace(None)
+      functionNS['jats-full-name'] = fn_jats_full_name
+      assert list(xml.xpath('jats-full-name(//name)')) == ['Tom Thomson']

--- a/sciencebeam_judge/evaluation_pipeline.py
+++ b/sciencebeam_judge/evaluation_pipeline.py
@@ -55,6 +55,8 @@ from sciencebeam_judge.grobid_evaluate import (
   format_summary_by_scoring_method as format_grobid_summary
 )
 
+from .xpath_functions import register_functions
+
 def get_logger():
   return logging.getLogger(__name__)
 
@@ -372,7 +374,12 @@ def add_main_args(parser):
   parser.add_argument(
     '--fields',
     type=comma_separated_str_to_list,
-    default=['abstract', 'authors', 'first_author', 'keywords', 'title'],
+    default=[
+      'abstract',
+      'author_surnames', 'first_author_surname',
+      'author_full_names', 'first_author_full_name',
+      'keywords', 'title'
+    ],
     help='comma separated list of fields to process'
   )
 
@@ -408,6 +415,8 @@ def parse_args(argv=None):
   return args
 
 def run(argv=None):
+  register_functions()
+
   args = parse_args(argv)
 
   # We use the save_main_session option because one or more DoFn's in this

--- a/sciencebeam_judge/evaluation_utils.py
+++ b/sciencebeam_judge/evaluation_utils.py
@@ -5,7 +5,7 @@ import re
 import logging
 from difflib import SequenceMatcher
 
-from six import iteritems, raise_from, string_types
+from six import iteritems, raise_from, string_types, text_type
 from six.moves.configparser import ConfigParser
 
 from lxml import etree as ET
@@ -26,7 +26,10 @@ def mean(data):
   return sum(data) / len(data)
 
 def get_full_text(e):
-  return "".join(e.itertext())
+  try:
+    return "".join(e.itertext())
+  except AttributeError:
+    return text_type(e)
 
 def get_full_text_ignore_children(e, children_to_ignore):
   if children_to_ignore is None or len(children_to_ignore) == 0:

--- a/sciencebeam_judge/jats_xpath_functions.py
+++ b/sciencebeam_judge/jats_xpath_functions.py
@@ -1,0 +1,57 @@
+import logging
+
+from lxml import etree
+
+LOGGER = logging.getLogger(__name__)
+
+def _name_node(node):
+  if node.tag != 'name':
+    return node.find('name')
+  return node
+
+def _filter_truthy(iterable):
+  return [x for x in iterable if x]
+
+def _filter_not_none(iterable):
+  return [x for x in iterable if x is not None]
+
+def _text(nodes):
+  return _filter_truthy(x.text for x in nodes)
+
+def _name_full_name(name_node):
+  return ' '.join(_text(_filter_not_none(
+    [name_node.find('given-names'), name_node.find('surname')]
+  )))
+
+def _contrib_full_name(contrib_node):
+  name_node = _name_node(contrib_node)
+  if name_node is not None:
+    return _name_full_name(name_node)
+  string_name_node = contrib_node.find('string-name')
+  if string_name_node is not None:
+    return string_name_node.text
+  return None
+
+def fn_jats_full_name(_, nodes):
+  result = _filter_not_none([
+    _contrib_full_name(node)
+    for node in nodes
+  ])
+  LOGGER.debug('fn_jats_full_name, nodes: %s, result: %s', nodes, result)
+  return result
+
+def fn_jats_authors(_, nodes):
+  return [
+    author
+    for node in nodes
+    for author in node.xpath(
+      'front/article-meta/contrib-group[not(@contrib-type) or @contrib-type="author"]'
+      '/contrib[not(@contrib-type) or @contrib-type="author" or @contrib-type="person"]'
+    )
+  ]
+
+def register_functions(ns=None):
+  if ns is None:
+    ns = etree.FunctionNamespace(None)
+  ns['jats-full-name'] = fn_jats_full_name
+  ns['jats-authors'] = fn_jats_authors

--- a/sciencebeam_judge/jats_xpath_functions_test.py
+++ b/sciencebeam_judge/jats_xpath_functions_test.py
@@ -1,0 +1,88 @@
+from lxml.builder import E
+
+from .jats_xpath_functions import register_functions
+
+class TestJatsXpathFunctions(object):
+  class TestAuthors(object):
+    def test_should_return_single_author_node(self):
+      contrib = E.contrib(
+        E.name(
+          E('given-names', 'Tom'),
+          E('surname', 'Thomson')
+        )
+      )
+      xml = E.article(
+        E.front(
+          E('article-meta', E('contrib-group', contrib))
+        )
+      )
+      register_functions()
+      assert list(xml.xpath('jats-authors(.)')) == [contrib]
+
+  class TestFullName(object):
+    def test_should_return_full_name_of_single_name(self):
+      xml = E.article(
+        E.name(
+          E('given-names', 'Tom'),
+          E('surname', 'Thomson')
+        )
+      )
+      register_functions()
+      assert list(xml.xpath('jats-full-name(//name)')) == ['Tom Thomson']
+
+    def test_should_return_full_name_of_single_contrib(self):
+      xml = E.article(
+        E.contrib(
+          E.name(
+            E('given-names', 'Tom'),
+            E('surname', 'Thomson')
+          )
+        )
+      )
+      register_functions()
+      assert list(xml.xpath('jats-full-name(//contrib)')) == ['Tom Thomson']
+
+    def test_should_not_add_space_if_surname_is_missing(self):
+      xml = E.article(
+        E.contrib(
+          E.name(
+            E('given-names', 'Tom')
+          )
+        )
+      )
+      register_functions()
+      assert list(xml.xpath('jats-full-name(//contrib)')) == ['Tom']
+
+    def test_should_not_add_space_if_surname_is_empty(self):
+      xml = E.article(
+        E.contrib(
+          E.name(
+            E('given-names', 'Tom'),
+            E.surname()
+          )
+        )
+      )
+      register_functions()
+      assert list(xml.xpath('jats-full-name(//contrib)')) == ['Tom']
+
+    def test_should_return_ignore_node_if_node_is_none(self):
+      xml = E.article(
+        E.contrib(
+          E.name(
+            E('given-names', 'Tom')
+          )
+        )
+      )
+      register_functions()
+      assert list(xml.xpath('jats-full-name(//contrib[2])')) == []
+
+    def test_should_return_ignore_node_without_name(self):
+      xml = E.article(
+        E.contrib(
+          E.other(
+            E('given-names', 'Tom')
+          )
+        )
+      )
+      register_functions()
+      assert list(xml.xpath('jats-full-name(//contrib)')) == []

--- a/sciencebeam_judge/tei_xpath_functions.py
+++ b/sciencebeam_judge/tei_xpath_functions.py
@@ -1,0 +1,54 @@
+import logging
+
+from lxml import etree
+
+LOGGER = logging.getLogger(__name__)
+
+def _pers_name_node(node):
+  if node.tag != 'persName':
+    return node.find('persName')
+  else:
+    return node
+
+def _filter_truthy(iterable):
+  return [x for x in iterable if x]
+
+def _filter_not_none(iterable):
+  return [x for x in iterable if x is not None]
+
+def _text(nodes):
+  return _filter_truthy(x.text for x in nodes)
+
+def _pers_name_full_name(pers_name_node):
+  return ' '.join(_text(_filter_not_none(
+    list(pers_name_node.findall('forename')) + [pers_name_node.find('surname')]
+  )))
+
+def _author_full_name(author_node):
+  name_node = _pers_name_node(author_node)
+  if name_node is not None:
+    return _pers_name_full_name(name_node)
+  return None
+
+def fn_tei_full_name(_, nodes):
+  result = _filter_not_none([
+    _author_full_name(node)
+    for node in nodes
+  ])
+  LOGGER.debug('fn_tei_full_name, nodes: %s, result: %s', nodes, result)
+  return result
+
+def fn_tei_authors(_, nodes):
+  return [
+    author
+    for node in nodes
+    for author in node.xpath(
+      'teiHeader/fileDesc/sourceDesc/biblStruct/analytic/author'
+    )
+  ]
+
+def register_functions(ns=None):
+  if ns is None:
+    ns = etree.FunctionNamespace(None)
+  ns['tei-full-name'] = fn_tei_full_name
+  ns['tei-authors'] = fn_tei_authors

--- a/sciencebeam_judge/tei_xpath_functions_test.py
+++ b/sciencebeam_judge/tei_xpath_functions_test.py
@@ -1,0 +1,84 @@
+from lxml.builder import E
+
+from .tei_xpath_functions import register_functions
+
+class TestTeiXpathFunctions(object):
+  class TestAuthors(object):
+    def test_should_return_single_author_node(self):
+      author = E.author(
+        E.persName(
+          E.forename('Tom'),
+          E.surname('Thomson')
+        )
+      )
+      xml = E.TEI(E.teiHeader(E.fileDesc(E.sourceDesc(E.biblStruct(E.analytic(
+        author
+      ))))))
+      register_functions()
+      assert list(xml.xpath('tei-authors(.)')) == [author]
+
+  class TestFullName(object):
+    def test_should_return_full_name_of_single_pers_name(self):
+      author = E.author(
+        E.persName(
+          E.forename('Tom'),
+          E.surname('Thomson')
+        )
+      )
+      xml = E.TEI(E.teiHeader(E.fileDesc(E.sourceDesc(E.biblStruct(E.analytic(
+        author
+      ))))))
+      register_functions()
+      assert list(xml.xpath('tei-full-name(//persName)')) == ['Tom Thomson']
+
+    def test_should_return_full_name_of_multiple_forenames(self):
+      author = E.author(
+        E.persName(
+          E.forename('Tom', type='first'),
+          E.forename('T', type='middle'),
+          E.surname('Thomson')
+        )
+      )
+      xml = E.TEI(E.teiHeader(E.fileDesc(E.sourceDesc(E.biblStruct(E.analytic(
+        author
+      ))))))
+      register_functions()
+      assert list(xml.xpath('tei-full-name(//persName)')) == ['Tom T Thomson']
+
+    def test_should_return_full_name_of_single_author(self):
+      author = E.author(
+        E.persName(
+          E.forename('Tom'),
+          E.surname('Thomson')
+        )
+      )
+      xml = E.TEI(E.teiHeader(E.fileDesc(E.sourceDesc(E.biblStruct(E.analytic(
+        author
+      ))))))
+      register_functions()
+      assert list(xml.xpath('tei-full-name(//author)')) == ['Tom Thomson']
+
+    def test_should_not_add_space_if_surname_is_missing(self):
+      author = E.author(
+        E.persName(
+          E.forename('Tom')
+        )
+      )
+      xml = E.TEI(E.teiHeader(E.fileDesc(E.sourceDesc(E.biblStruct(E.analytic(
+        author
+      ))))))
+      register_functions()
+      assert list(xml.xpath('tei-full-name(//author)')) == ['Tom']
+
+    def test_should_not_add_space_if_surname_is_empty(self):
+      author = E.author(
+        E.persName(
+          E.forename('Tom'),
+          E.surname()
+        )
+      )
+      xml = E.TEI(E.teiHeader(E.fileDesc(E.sourceDesc(E.biblStruct(E.analytic(
+        author
+      ))))))
+      register_functions()
+      assert list(xml.xpath('tei-full-name(//author)')) == ['Tom']

--- a/sciencebeam_judge/xpath_functions.py
+++ b/sciencebeam_judge/xpath_functions.py
@@ -1,0 +1,6 @@
+from . import jats_xpath_functions
+from . import tei_xpath_functions
+
+def register_functions(ns=None):
+  jats_xpath_functions.register_functions(ns)
+  tei_xpath_functions.register_functions(ns)

--- a/xml-mapping.conf
+++ b/xml-mapping.conf
@@ -1,13 +1,21 @@
 [article]
 title = front/article-meta/title-group/article-title
 abstract = front/article-meta/abstract
-first_author = front/article-meta/contrib-group/contrib[1]/name/surname
-authors = front/article-meta/contrib-group/contrib[not(@contrib-type) or @contrib-type="author"]/name/surname
+
+first_author_surname = jats-authors(.)[1]/name/surname
+author_surnames = jats-authors(.)/name/surname
+first_author_full_name = jats-full-name(jats-authors(.)[1])
+author_full_names = jats-full-name(jats-authors(.))
+
 keywords = front/article-meta/kwd-group/kwd
 
 [TEI]
 title = teiHeader/fileDesc/titleStmt/title
 abstract = teiHeader/profileDesc/abstract
-first_author = teiHeader/fileDesc/sourceDesc/biblStruct/analytic/author[1]/persName/surname
-authors = teiHeader/fileDesc/sourceDesc/biblStruct/analytic/author/persName/surname
+
+first_author_surname = tei-authors(.)[1]/persName/surname
+author_surnames = tei-authors(.)/persName/surname
+first_author_full_name = tei-full-name(tei-authors(.)[1])
+author_full_names = tei-full-name(tei-authors(.))
+
 keywords = teiHeader/profileDesc/textClass/keywords/term


### PR DESCRIPTION
Part of the OTS evaluation, we needed to add the option to evaluate the full name.
It also required normalising the name more (OTS/cermine result may provide a single string for the name whereas GROBID other DAR JATS output includes individual name fields, e.g. first name, last name)