### PR TITLE
removed deprecated process_sciencebeam_gym_dep_args

### DIFF
--- a/sciencebeam_judge/evaluation_pipeline.py
+++ b/sciencebeam_judge/evaluation_pipeline.py
@@ -31,8 +31,7 @@ from sciencebeam_utils.beam_utils.io import (
 
 from sciencebeam_utils.beam_utils.main import (
     add_cloud_args,
-    process_cloud_args,
-    process_sciencebeam_gym_dep_args
+    process_cloud_args
 )
 
 from sciencebeam_utils.utils.file_list import (
@@ -577,7 +576,6 @@ def parse_args(argv=None):
         args, args.output_path,
         name='sciencebeam-judge'
     )
-    process_sciencebeam_gym_dep_args(args)
 
     get_logger().info('args: %s', args)
 


### PR DESCRIPTION
should have been removed when we switched to `sciencebeam-utils`.