### PR TITLE
pinned minimal-notebook version

### DIFF
--- a/Dockerfile.jupyter
+++ b/Dockerfile.jupyter
@@ -1,4 +1,4 @@
-FROM jupyter/minimal-notebook
+FROM jupyter/minimal-notebook:9e8682c9ea54
 
 ENV PROJECT_HOME=/home/jovyan/sciencebeam-judge
 


### PR DESCRIPTION
The latest version it's showing warnings in the notebook:
```
      "/opt/conda/lib/python3.7/site-packages/matplotlib/cbook/__init__.py:2349: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working\n",
      "  if isinstance(obj, collections.Iterator):\n",
```

This will pin it to the last tag that doesn't show the warning. Raised #51 to upgrade to the latest version of minimal-notebook (I'm assuming with Python 3.7).