### PR TITLE
use html for markdown output

### DIFF
--- a/notebooks/conversion-results-details.ipynb
+++ b/notebooks/conversion-results-details.ipynb
@@ -88,7 +88,7 @@
     "\n",
     "import pandas as pd\n",
     "from markdown import markdown\n",
-    "from IPython.display import display, Markdown, HTML\n",
+    "from IPython.display import display, HTML\n",
     "\n",
     "warnings.filterwarnings('default')"
    ]
@@ -233,7 +233,7 @@
     "        s = s.decode('unicode_escape')\n",
     "    except AttributeError:\n",
     "        pass\n",
-    "    display(Markdown(s))"
+    "    display(HTML(markdown(s)))"
    ]
   },
   {
@@ -283,11 +283,11 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "## Details Files"
+      "text/html": [
+       "<h2>Details Files</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -295,11 +295,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "**Timestamp:** 2019-01-11 10:01:47.597541 (pmc-sample-1943-cc-by-subset grobid-tei)"
+      "text/html": [
+       "<p><strong>Timestamp:</strong> 2019-01-11 10:01:47.597541 (pmc-sample-1943-cc-by-subset grobid-tei)</p>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -307,11 +307,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "**Timestamp:** 2019-01-11 10:01:31.996741 (pmc-sample-1943-cc-by-subset cermine)"
+      "text/html": [
+       "<p><strong>Timestamp:</strong> 2019-01-11 10:01:31.996741 (pmc-sample-1943-cc-by-subset cermine)</p>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -330,11 +330,11 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "### Evaluation File States"
+      "text/html": [
+       "<h3>Evaluation File States</h3>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -342,11 +342,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "**Evaluation methods:** exact, levenshtein"
+      "text/html": [
+       "<p><strong>Evaluation methods:</strong> exact, levenshtein</p>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -354,11 +354,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "**Field names:** abstract, affiliation_institution, affiliation_strings, author_full_names, author_surnames, first_author_full_name, first_author_surname, first_reference_fields, first_reference_title, keywords, reference_fields, reference_fpage, reference_lpage, reference_source, reference_title, reference_volume, reference_year, section_titles, table_captions, table_label_captions, table_labels, table_strings, tables, title"
+      "text/html": [
+       "<p><strong>Field names:</strong> abstract, affiliation_institution, affiliation_strings, author_full_names, author_surnames, first_author_full_name, first_author_surname, first_reference_fields, first_reference_title, keywords, reference_fields, reference_fpage, reference_lpage, reference_source, reference_title, reference_volume, reference_year, section_titles, table_captions, table_label_captions, table_labels, table_strings, tables, title</p>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -409,11 +409,11 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "# Comparing results between tools"
+      "text/html": [
+       "<h1>Comparing results between tools</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -421,11 +421,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -433,11 +433,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: title"
+      "text/html": [
+       "<h1>Field: title</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -445,11 +445,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (title levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (title levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -480,11 +480,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (title exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (title exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -518,11 +518,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -530,11 +530,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: first_author_full_name"
+      "text/html": [
+       "<h1>Field: first_author_full_name</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -542,11 +542,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (first_author_full_name levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (first_author_full_name levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -584,11 +584,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (first_author_full_name exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (first_author_full_name exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -624,11 +624,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -636,11 +636,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: author_full_names"
+      "text/html": [
+       "<h1>Field: author_full_names</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -648,11 +648,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (author_full_names levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (author_full_names levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -694,11 +694,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (author_full_names exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (author_full_names exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -742,11 +742,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -754,11 +754,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: abstract"
+      "text/html": [
+       "<h1>Field: abstract</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -766,11 +766,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (abstract levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (abstract levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -805,11 +805,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (abstract exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (abstract exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -841,11 +841,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -853,11 +853,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: section_titles"
+      "text/html": [
+       "<h1>Field: section_titles</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -865,11 +865,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (section_titles levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (section_titles levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -913,11 +913,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (section_titles exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (section_titles exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -961,11 +961,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -973,11 +973,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: affiliation_strings"
+      "text/html": [
+       "<h1>Field: affiliation_strings</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -985,11 +985,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (affiliation_strings levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (affiliation_strings levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1032,11 +1032,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (affiliation_strings exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (affiliation_strings exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1074,11 +1074,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1086,11 +1086,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: affiliation_institution"
+      "text/html": [
+       "<h1>Field: affiliation_institution</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1098,11 +1098,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (affiliation_institution levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (affiliation_institution levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1143,11 +1143,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (affiliation_institution exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (affiliation_institution exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1187,11 +1187,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1199,11 +1199,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: first_reference_fields"
+      "text/html": [
+       "<h1>Field: first_reference_fields</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1211,11 +1211,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (first_reference_fields levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (first_reference_fields levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1248,11 +1248,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (first_reference_fields exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (first_reference_fields exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1284,11 +1284,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1296,11 +1296,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: first_reference_title"
+      "text/html": [
+       "<h1>Field: first_reference_title</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1308,11 +1308,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (first_reference_title levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (first_reference_title levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1342,11 +1342,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (first_reference_title exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (first_reference_title exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1376,11 +1376,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1388,11 +1388,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: reference_fields"
+      "text/html": [
+       "<h1>Field: reference_fields</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1400,11 +1400,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_fields levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_fields levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1447,11 +1447,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_fields exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_fields exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1495,11 +1495,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1507,11 +1507,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: reference_title"
+      "text/html": [
+       "<h1>Field: reference_title</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1519,11 +1519,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_title levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_title levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1566,11 +1566,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_title exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_title exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1614,11 +1614,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1626,11 +1626,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: reference_year"
+      "text/html": [
+       "<h1>Field: reference_year</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1638,11 +1638,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_year levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_year levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1685,11 +1685,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_year exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_year exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1732,11 +1732,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1744,11 +1744,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: reference_source"
+      "text/html": [
+       "<h1>Field: reference_source</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1756,11 +1756,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_source levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_source levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1803,11 +1803,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_source exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_source exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1849,11 +1849,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1861,11 +1861,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: reference_volume"
+      "text/html": [
+       "<h1>Field: reference_volume</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1873,11 +1873,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_volume levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_volume levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1921,11 +1921,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_volume exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_volume exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1969,11 +1969,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1981,11 +1981,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: reference_fpage"
+      "text/html": [
+       "<h1>Field: reference_fpage</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -1993,11 +1993,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_fpage levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_fpage levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2040,11 +2040,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_fpage exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_fpage exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2087,11 +2087,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2099,11 +2099,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: reference_lpage"
+      "text/html": [
+       "<h1>Field: reference_lpage</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2111,11 +2111,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_lpage levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_lpage levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2158,11 +2158,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (reference_lpage exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (reference_lpage exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2205,11 +2205,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2217,11 +2217,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: tables"
+      "text/html": [
+       "<h1>Field: tables</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2229,11 +2229,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (tables levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (tables levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2265,11 +2265,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (tables exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (tables exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2301,11 +2301,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2313,11 +2313,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: table_strings"
+      "text/html": [
+       "<h1>Field: table_strings</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2325,11 +2325,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (table_strings levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (table_strings levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2367,11 +2367,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (table_strings exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (table_strings exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2403,11 +2403,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2415,11 +2415,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: table_labels"
+      "text/html": [
+       "<h1>Field: table_labels</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2427,11 +2427,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (table_labels levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (table_labels levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2467,11 +2467,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (table_labels exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (table_labels exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2506,11 +2506,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2518,11 +2518,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: table_captions"
+      "text/html": [
+       "<h1>Field: table_captions</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2530,11 +2530,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (table_captions levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (table_captions levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2566,11 +2566,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (table_captions exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (table_captions exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2602,11 +2602,11 @@
     },
     {
      "data": {
-      "text/markdown": [
+      "text/html": [
        "<hr/>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2614,11 +2614,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "# Field: table_label_captions"
+      "text/html": [
+       "<h1>Field: table_label_captions</h1>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2626,11 +2626,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (table_label_captions levenshtein)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (table_label_captions levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -2667,11 +2667,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## Dataset: pmc-sample-1943-cc-by-subset (table_label_captions exact)"
+      "text/html": [
+       "<h2>Dataset: pmc-sample-1943-cc-by-subset (table_label_captions exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},

--- a/notebooks/conversion-results-summary.ipynb
+++ b/notebooks/conversion-results-summary.ipynb
@@ -86,7 +86,8 @@
     "import re\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
-    "from IPython.display import display, HTML, Markdown\n",
+    "from markdown import markdown\n",
+    "from IPython.display import display, HTML\n",
     "\n",
     "warnings.filterwarnings('default')"
    ]
@@ -159,7 +160,7 @@
     "        s = s.decode('unicode_escape')\n",
     "    except AttributeError:\n",
     "        pass\n",
-    "    display(Markdown(s))"
+    "    display(HTML(markdown(s)))"
    ]
   },
   {
@@ -169,11 +170,11 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "## Summary Files"
+      "text/html": [
+       "<h2>Summary Files</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -181,11 +182,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "**Timestamp:** 2019-01-11 10:01:49.013612 (pmc-sample-1943-cc-by-subset grobid-tei)"
+      "text/html": [
+       "<p><strong>Timestamp:</strong> 2019-01-11 10:01:49.013612 (pmc-sample-1943-cc-by-subset grobid-tei)</p>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -193,11 +194,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "**Timestamp:** 2019-01-11 10:01:33.188804 (pmc-sample-1943-cc-by-subset cermine)"
+      "text/html": [
+       "<p><strong>Timestamp:</strong> 2019-01-11 10:01:33.188804 (pmc-sample-1943-cc-by-subset cermine)</p>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -238,11 +239,11 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "### Evaluation File States"
+      "text/html": [
+       "<h3>Evaluation File States</h3>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -250,11 +251,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "**Evaluation methods:** exact, levenshtein"
+      "text/html": [
+       "<p><strong>Evaluation methods:</strong> exact, levenshtein</p>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -262,11 +263,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "**Field names:** abstract, affiliation_institution, affiliation_strings, author_full_names, author_surnames, first_author_full_name, first_author_surname, first_reference_fields, first_reference_title, keywords, reference_fields, reference_fpage, reference_lpage, reference_source, reference_title, reference_volume, reference_year, section_titles, table_captions, table_label_captions, table_labels, table_strings, tables, title"
+      "text/html": [
+       "<p><strong>Field names:</strong> abstract, affiliation_institution, affiliation_strings, author_full_names, author_surnames, first_author_full_name, first_author_surname, first_reference_fields, first_reference_title, keywords, reference_fields, reference_fpage, reference_lpage, reference_source, reference_title, reference_volume, reference_year, section_titles, table_captions, table_label_captions, table_labels, table_strings, tables, title</p>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -302,11 +303,11 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "## pmc-sample-1943-cc-by-subset (levenshtein)"
+      "text/html": [
+       "<h2>pmc-sample-1943-cc-by-subset (levenshtein)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -314,11 +315,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "**Note:** sample size of **10** is too small to provide a meaningful insight"
+      "text/html": [
+       "<p><strong>Note:</strong> sample size of <strong>10</strong> is too small to provide a meaningful insight</p>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -326,11 +327,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "grobid-tei: #10, cermine: #10 (max: 10)"
+      "text/html": [
+       "<p>grobid-tei: #10, cermine: #10 (max: 10)</p>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -551,11 +552,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "## pmc-sample-1943-cc-by-subset (exact)"
+      "text/html": [
+       "<h2>pmc-sample-1943-cc-by-subset (exact)</h2>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -563,11 +564,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "**Note:** sample size of **10** is too small to provide a meaningful insight"
+      "text/html": [
+       "<p><strong>Note:</strong> sample size of <strong>10</strong> is too small to provide a meaningful insight</p>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -575,11 +576,11 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "grobid-tei: #10, cermine: #10 (max: 10)"
+      "text/html": [
+       "<p>grobid-tei: #10, cermine: #10 (max: 10)</p>"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},


### PR DESCRIPTION
This is a workaround for https://github.com/jupyter/notebook/issues/4339

The notebook might become untrusted locally or when someone else opens it (without re-running it). In that case the Markdown output isn't currently shown. But HTML is.