### PR TITLE
run update-example-data-results and -notebooks as part of build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,14 @@ elifeLibrary {
                 commit
             )
         }
+
+        stage 'Test update evaluation results', {
+            sh "bash ./update-example-data-results.sh"
+        }
+
+        stage 'Test update notebooks', {
+            sh "bash ./update-example-data-notebooks.sh"
+        }
     }
 
     elifeMainlineOnly {


### PR DESCRIPTION
This will test that the notebook isn't or doesn't seem to be broken (e.g. `matplotlib` is only used by the notebook).

The scripts will run `docker-compose --rm` - not sure if we need a `docker-compose down -v`.
It will also not use `docker-compose.ci.yml` for those steps.