### PR TITLE
push unstable image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,13 @@ elifePipeline {
             stage 'Merge to master', {
                 elifeGitMoveToBranch commit, 'master'
             }
+
+            stage 'Push unstable image', {
+                def image = DockerImage.elifesciences(this, 'sciencebeam_judge', commit)
+                def unstable_image = image.addSuffixAndTag('_unstable', commit)
+                unstable_image.tag('latest').push()
+                unstable_image.push()
+            }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ elifePipeline {
             }
 
             stage 'Push unstable image', {
-                def image = DockerImage.elifesciences(this, 'sciencebeam_judge', commit)
+                def image = DockerImage.elifesciences(this, 'sciencebeam-judge', commit)
                 def unstable_image = image.addSuffixAndTag('_unstable', commit)
                 unstable_image.tag('latest').push()
                 unstable_image.push()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,12 @@
-elifeLibrary {
-    def commit
-
-    stage 'Checkout', {
-        checkout scm
-        commit = elifeGitRevision()
-    }
-
+elifePipeline {
     node('containers-jenkins-plugin') {
+        def commit
+
+        stage 'Checkout', {
+            checkout scm
+            commit = elifeGitRevision()
+        }
+
         stage 'Build images', {
             checkout scm
             dockerComposeBuild(commit)
@@ -27,11 +27,11 @@ elifeLibrary {
         stage 'Test update notebooks', {
             sh "bash ./update-example-data-notebooks.sh"
         }
-    }
 
-    elifeMainlineOnly {
-        stage 'Merge to master', {
-            elifeGitMoveToBranch commit, 'master'
+        elifeMainlineOnly {
+            stage 'Merge to master', {
+                elifeGitMoveToBranch commit, 'master'
+            }
         }
     }
 }


### PR DESCRIPTION
Starting with an unstable image. We can add a release process in the future.

(This is to allow us to use the image as part of the pipeline, which currently builds the image using gcloud build)