### PR TITLE
updated xml mapping to only match first training tei title

### DIFF
--- a/sciencebeam_judge/default_xml_mapping_test.py
+++ b/sciencebeam_judge/default_xml_mapping_test.py
@@ -72,6 +72,14 @@ class TestDefaultXmlMapping(object):
                 result = _parse_xml(BytesIO(etree.tostring(xml)), xml_mapping=default_xml_mapping)
                 assert result.get('title') == ['Title 1']
 
+            def test_should_only_match_first_title(self, default_xml_mapping):
+                xml = E.tei(E.text(E.front(
+                    E.docTitle(E.titlePart('Title 1')),
+                    E.docTitle(E.titlePart('Title 2')),
+                )))
+                result = _parse_xml(BytesIO(etree.tostring(xml)), xml_mapping=default_xml_mapping)
+                assert result.get('title') == ['Title 1']
+
         class TestTeiTrainingAbstract(object):
             def test_should_extract_title(self, default_xml_mapping):
                 xml = E.tei(E.text(E.front(

--- a/xml-mapping.conf
+++ b/xml-mapping.conf
@@ -84,5 +84,5 @@ figure_captions = text/body//figure[not(contains(@type, 'table'))]/figDesc
 figure_label_captions = generic-concat-children(text/body//figure[not(contains(@type, 'table'))], '$head', ' ', '$figDesc')
 
 [tei]
-title = text/front/docTitle/titlePart
+title = text/front/docTitle[1]/titlePart
 abstract = text/front/div[@type="abstract"]


### PR DESCRIPTION
The example training data may contain the title multiple times, e.g. when it appears in the heading.