### PR TITLE
added papermill and gcloud sdk to jupyter image for offline notebook rendering

### DIFF
--- a/Dockerfile.jupyter
+++ b/Dockerfile.jupyter
@@ -1,5 +1,27 @@
 FROM jupyter/minimal-notebook:9e8682c9ea54
 
+USER root
+
+# install gcloud to make it easier to access cloud storage
+# gcloud sdk cli only works with Python 2 (in 2019)
+ARG install_gcloud=y
+RUN if [ "${install_gcloud}" = "y" ]; then \
+      apt-get update \
+      && apt-get install --assume-yes --no-install-recommends \
+        curl python2.7 \
+      && rm -rf /var/lib/apt/lists/* \
+      && mkdir -p /usr/local/gcloud \
+      && curl -q https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz \
+        -o /tmp/google-cloud-sdk.tar.gz \
+      && tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
+      && rm /tmp/google-cloud-sdk.tar.gz \
+      && /usr/local/gcloud/google-cloud-sdk/install.sh; \
+    fi
+
+USER jovyan
+
+ENV PATH /usr/local/gcloud/google-cloud-sdk/bin:$PATH
+
 ENV PROJECT_HOME=/home/jovyan/sciencebeam-judge
 
 WORKDIR ${PROJECT_HOME}

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ jupyter-build:
 	docker-compose build sciencebeam-judge-jupyter
 
 
+jupyter-shell: jupyter-build
+	docker-compose run --rm sciencebeam-judge-jupyter bash
+
+
 jupyter-start: jupyter-build
 	docker-compose up -d sciencebeam-judge-jupyter
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,3 +10,4 @@ services:
     sciencebeam-judge-jupyter:
         volumes:
             - .:/home/jovyan/sciencebeam-judge
+            - ~/.config/gcloud:/home/jovyan/.config/gcloud

--- a/requirements.notebook.txt
+++ b/requirements.notebook.txt
@@ -1,3 +1,4 @@
 Markdown==3.1
 matplotlib==3.0.3
 pandas==0.24.2
+papermill==1.0.0


### PR DESCRIPTION
Papermill helps with passing parameters in to notebooks.
While the gcloud sdk will be used to download files from cloud storage (within Kubernetes / GKE the credentials will be magically available).