### PR TITLE
revert temporary git changes after updating notebook

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,10 @@ elifePipeline {
             sh "bash ./update-example-data-notebooks.sh"
         }
 
+        stage 'Revert temporary git changes', {
+            sh "git checkout ."
+        }
+
         elifeMainlineOnly {
             stage 'Merge to master', {
                 elifeGitMoveToBranch commit, 'master'


### PR DESCRIPTION
The [recent build](https://alfred.elifesciences.org/job/libraries/job/library-sciencebeam-judge/90/console) failed when checkout out master due to changes in the notebook. This will revert any local git changes before switching to master.