### PR TITLE
fixed tei raw affiliation empty if label present

### DIFF
--- a/sciencebeam_judge/parsing/xpath/tei_xpath_functions.py
+++ b/sciencebeam_judge/parsing/xpath/tei_xpath_functions.py
@@ -24,8 +24,10 @@ def _filter_not_none(iterable):
     return [x for x in iterable if x is not None]
 
 
-def _text(nodes):
-    return _filter_truthy(x.text for x in nodes)
+def _text(nodes: List[etree.Element]) -> List[str]:
+    return _filter_truthy(
+        get_text_content(x) for x in nodes
+    )
 
 
 def _pers_name_full_name(pers_name_node):

--- a/tests/parsing/xpath/tei_xpath_functions_test.py
+++ b/tests/parsing/xpath/tei_xpath_functions_test.py
@@ -146,7 +146,7 @@ class TestTeiXpathFunctions(object):
                 ['Department 1, Post Code 1, Settlement 1, Country 1']
             )
 
-        def test_should_use_raw_affiliation_note_if_available(self):
+        def test_should_use_raw_affiliation_note_without_label_if_available(self):
             xml = E.TEI(
                 E.affiliation(
                     E.note('raw affiliation 1', type='raw_affiliation'),
@@ -161,6 +161,27 @@ class TestTeiXpathFunctions(object):
             assert (
                 list(xml.xpath('tei-aff-string(//affiliation)')) ==
                 ['raw affiliation 1']
+            )
+
+        def test_should_use_raw_affiliation_note_with_label_if_available(self):
+            xml = E.TEI(
+                E.affiliation(
+                    E.note(
+                        E.label('a'),
+                        ' raw affiliation 1',
+                        type='raw_affiliation'
+                    ),
+                    E.orgName('Department 1', type="department"),
+                    E.address(
+                        E.postCode('Post Code 1'),
+                        E.settlement('Settlement 1'),
+                        E.country('Country 1')
+                    )
+                )
+            )
+            assert (
+                list(xml.xpath('tei-aff-string(//affiliation)')) ==
+                ['a raw affiliation 1']
             )
 
         def test_should_join_institution_with_addr_line(self):


### PR DESCRIPTION
after including the label in the raw affiliation, this cause the value to be considered empty and give it a low score