### PR TITLE
added --scoring-type-overrides arg

### DIFF
--- a/sciencebeam_judge/evaluation_config.py
+++ b/sciencebeam_judge/evaluation_config.py
@@ -2,11 +2,20 @@ from typing import Dict, List
 
 from sciencebeam_utils.utils.string import parse_list
 
+from .utils.string import parse_dict
 from .utils.config import parse_config_as_dict
 
 
 def parse_evaluation_config(filename_or_fp) -> Dict[str, Dict[str, str]]:
     return parse_config_as_dict(filename_or_fp)
+
+
+def parse_scoring_type_overrides(
+        scoring_type_overrides_str: str) -> Dict[str, List[str]]:
+    return {
+        key: parse_list(value)
+        for key, value in parse_dict(scoring_type_overrides_str).items()
+    }
 
 
 def get_scoring_types_by_field_map_from_config(

--- a/sciencebeam_judge/utils/string.py
+++ b/sciencebeam_judge/utils/string.py
@@ -1,0 +1,16 @@
+from typing import Dict, Tuple
+
+
+def parse_key_value(expr: str) -> Tuple[str, str]:
+    key, value = expr.split('=', maxsplit=1)
+    return key.strip(), value.strip()
+
+
+def parse_dict(expr: str, delimiter: str = '|') -> Dict[str, str]:
+    if not expr:
+        return {}
+    d = {}
+    for fragment in expr.split(delimiter):
+        key, value = parse_key_value(fragment)
+        d[key] = value
+    return d

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import logging
+from pathlib import Path
 
 import pytest
+from py._path.local import LocalPath
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -8,3 +10,9 @@ def setup_logging():
     logging.basicConfig(level='WARNING')
     for name in ['tests', 'sciencebeam_judge']:
         logging.getLogger(name).setLevel('DEBUG')
+
+
+@pytest.fixture
+def temp_dir(tmpdir: LocalPath):
+    # convert to standard Path
+    return Path(str(tmpdir))

--- a/tests/utils/string_test.py
+++ b/tests/utils/string_test.py
@@ -1,0 +1,22 @@
+from sciencebeam_judge.utils.string import parse_dict
+
+
+class TestParseDict:
+    def test_should_return_empty_dict_for_empty_expr(self):
+        assert parse_dict('') == {}
+
+    def test_should_parse_single_key_value_pair(self):
+        assert parse_dict('key1=value1') == {'key1': 'value1'}
+
+    def test_should_allow_equals_sign_in_value(self):
+        assert parse_dict('key1=value=1') == {'key1': 'value=1'}
+
+    def test_should_parse_multiple_key_value_pair(self):
+        assert parse_dict(
+            'key1=value1|key2=value2', delimiter='|'
+        ) == {'key1': 'value1', 'key2': 'value2'}
+
+    def test_should_ignore_spaces(self):
+        assert parse_dict(
+            ' key1 = value1 | key2 = value2 ', delimiter='|'
+        ) == {'key1': 'value1', 'key2': 'value2'}


### PR DESCRIPTION
allows the scoring type to be overridden (e.g. to save compute time)