### PR TITLE
fixed grobid evaluation without exact measure

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,7 +5,8 @@ disable=
     no-self-use,
     invalid-name,
     too-many-arguments,
-    duplicate-code
+    duplicate-code,
+    superfluous-parens
 
 [MASTER]
 ignored-classes=

--- a/sciencebeam_judge/grobid_evaluate.py
+++ b/sciencebeam_judge/grobid_evaluate.py
@@ -82,18 +82,18 @@ def format_summary_by_scoring_method(scores_by_scoring_method, keys):
     ]))
     print('available_keys:', available_keys, ', keys:', keys)
     keys = [k for k in keys if k in available_keys]
-    if not scores_by_scoring_method:
-        return ''
-    if 'exact' not in scores_by_scoring_method:
-        raise ValueError(
-            'invalid scores_by_scoring_method, expected "exact", but had: %s' %
-            scores_by_scoring_method.keys()
-        )
-    score_outputs = []
     score_measures = [
         ScoringMethodNames.EXACT, ScoringMethodNames.SOFT,
         ScoringMethodNames.LEVENSHTEIN, ScoringMethodNames.RATCLIFF_OBERSHELP
     ]
+    if not scores_by_scoring_method:
+        return ''
+    if not (set(score_measures) & set(scores_by_scoring_method.keys())):
+        raise ValueError(
+            'invalid scores_by_scoring_method, expected at least one of %s, but had: %s' %
+            (score_measures, scores_by_scoring_method.keys())
+        )
+    score_outputs = []
     for measure in score_measures:
         if measure in scores_by_scoring_method:
             score_outputs.append(

--- a/tests/grobid_evaluate_test.py
+++ b/tests/grobid_evaluate_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sciencebeam_judge.evaluation.scoring_methods import ScoringMethodNames
 from sciencebeam_judge.evaluation.scoring_types.scoring_types import ScoringTypeNames
 from sciencebeam_judge.evaluation.document_scoring import DocumentScoringProps
@@ -89,6 +91,23 @@ class TestFormatSummaryByScoringMethod:
         assert not format_summary_by_scoring_method(
             scores_by_scoring_method, [FIELD_1]
         ).endswith(' ')
+
+    def test_should_raise_error_if_invalid_scoring_method(self):
+        scores_by_scoring_method = {
+            'invalid': SUMMARY_SCORES
+        }
+        with pytest.raises(ValueError):
+            format_summary_by_scoring_method(
+                scores_by_scoring_method, [FIELD_1]
+            )
+
+    def test_not_should_raise_error_if_valid_scoring_method_is_present(self):
+        scores_by_scoring_method = {
+            ScoringMethodNames.LEVENSHTEIN: SUMMARY_SCORES
+        }
+        format_summary_by_scoring_method(
+            scores_by_scoring_method, [FIELD_1]
+        )
 
 
 class TestFormatSummarisedDocumentScoresAsGrobidReport:


### PR DESCRIPTION
avoid grobid evaluation failing when specifying scoring measures not including `exact` (e.g. only `levenshtein`)