### PR TITLE
added missing pytest marker config slow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ COPY *.conf *.sh *.in *.txt *.py /srv/sciencebeam-judge/
 
 # tests
 COPY tests ./tests
-COPY .pylintrc .flake8 ${PROJECT_HOME}/
+COPY .pylintrc .flake8 pytest.ini ${PROJECT_HOME}/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 testpaths = tests
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
to avoid the warning complaining about the unknown marker "slow"