### PR TITLE
added affiliation_by_label_text

### DIFF
--- a/tests/default_xml_mapping/tei_test.py
+++ b/tests/default_xml_mapping/tei_test.py
@@ -90,6 +90,32 @@ class TestTei:
             assert result.get('affiliation_institution') == ['Institution 1']
             assert result.get('affiliation_country') == ['Country 1']
 
+        def test_should_join_affiliation_text_with_same_label(
+                self, default_xml_mapping):
+            xml = E.TEI(E.teiHeader(E.fileDesc(E.sourceDesc(E.biblStruct(E.analytic(
+                E.author(
+                    E.affiliation(
+                        E.note({'type': 'raw_affiliation'}, E.label('a'), ' Part 1')
+                    ),
+                    E.affiliation(
+                        E.note({'type': 'raw_affiliation'}, E.label('a'), ' Part 2')
+                    ),
+                    E.affiliation(
+                        E.note({'type': 'raw_affiliation'}, E.label('b'), ' Other')
+                    )
+                )
+            ))))))
+            result = parse_xml_node(
+                xml,
+                xml_mapping=default_xml_mapping,
+                fields=[
+                    'affiliation_text',
+                    'affiliation_by_label_text'
+                ]
+            )
+            assert result.get('affiliation_text') == ['a Part 1', 'a Part 2', 'b Other']
+            assert result.get('affiliation_by_label_text') == ['a Part 1 Part 2', 'b Other']
+
     class TestTeiReferenceAuthorNames:
         def test_should_parse_tei_ref_authors(self, default_xml_mapping):
             xml = E.TEI(E.text(E.back(E.div(E.listBibl(

--- a/tests/parsing/xpath/tei_xpath_functions_test.py
+++ b/tests/parsing/xpath/tei_xpath_functions_test.py
@@ -323,6 +323,63 @@ class TestTeiXpathFunctions:
                 xml.xpath('tei-aff-string(//affiliation)')
             ) == ['raw affiliation 1', 'raw affiliation 2']
 
+    class TestAffByLabelText:
+        def test_should_return_emtpy_list_if_no_raw_affiliation_note_available(self):
+            xml = E.TEI(
+                E.affiliation(
+                    E.orgName('Department 1', type="department")
+                )
+            )
+            assert (
+                list(xml.xpath('tei-aff-by-label-text(//affiliation)')) ==
+                []
+            )
+
+        def test_should_use_raw_affiliation_note_without_label_if_available(self):
+            xml = E.TEI(
+                E.affiliation(
+                    E.note('raw affiliation 1', type='raw_affiliation'),
+                    E.orgName('Department 1', type="department")
+                )
+            )
+            assert (
+                list(xml.xpath('tei-aff-by-label-text(//affiliation)')) ==
+                ['raw affiliation 1']
+            )
+
+        def test_should_use_raw_affiliation_note_with_label_if_available(self):
+            xml = E.TEI(
+                E.affiliation(
+                    E.note(
+                        E.label('a'),
+                        ' raw affiliation 1',
+                        type='raw_affiliation'
+                    ),
+                    E.orgName('Department 1', type="department")
+                )
+            )
+            assert (
+                list(xml.xpath('tei-aff-by-label-text(//affiliation)')) ==
+                ['a raw affiliation 1']
+            )
+
+        def test_should_concatenate_raw_affiliation_notes_with_same_label(self):
+            xml = E.TEI(
+                E.affiliation(
+                    E.note(E.label('a'), ' part 1', type='raw_affiliation')
+                ),
+                E.affiliation(
+                    E.note(E.label('a'), ' part 2', type='raw_affiliation')
+                ),
+                E.affiliation(
+                    E.note(E.label('b'), ' other', type='raw_affiliation')
+                )
+            )
+            assert (
+                list(xml.xpath('tei-aff-by-label-text(//affiliation)')) ==
+                ['a part 1 part 2', 'b other']
+            )
+
     class TestRefFpage:
         def test_should_return_from_attribute_if_present(self):
             xml = E.TEI(E.biblStruct(E.monogr(E.imprint(

--- a/xml-mapping.conf
+++ b/xml-mapping.conf
@@ -33,6 +33,8 @@ corresp_author_emails = jats-author-email(jats-authors(.)[@corresp="yes"])
 author_emails = jats-author-email(jats-authors(.))
 
 affiliation_text = generic-normalized-text-content(front//aff)
+# Note: currently there is no need to join affiliation text by label for JATS
+affiliation_by_label_text = generic-normalized-text-content(front//aff)
 affiliation_strings = jats-aff-string(front//aff)
 affiliation_label = generic-join-children(front//aff, 'label', ', ')
 affiliation_institution = generic-join-children(front//aff, 'institution', ', ')
@@ -125,6 +127,7 @@ corresp_author_emails = tei-authors(.)[@role="corresp"]/email
 author_emails = tei-authors(.)/email
 
 affiliation_text = tei-aff-text(tei-author-affiliations(.))
+affiliation_by_label_text = tei-aff-by-label-text(tei-author-affiliations(.))
 affiliation_strings = tei-aff-string(tei-author-affiliations(.))
 affiliation_label = (tei-author-affiliations(.))/note[@type="raw_affiliation"]/label
 affiliation_institution = generic-join-children(tei-author-affiliations(.), 'orgName', ', ')


### PR DESCRIPTION
This allows the raw affiliations text with the same label to be joined together for evaluation purpose.