### PR TITLE
revise distance matching implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,15 @@ dev-watch:
 dev-test: dev-lint dev-pytest
 
 
+dev-update-example-data-results:
+	$(PYTHON) -m sciencebeam_judge.evaluation_pipeline \
+		--target-file-list $(EXAMPLE_DATA_EXPECTED_BASE_PATH)/file-list.tsv \
+		--target-file-column=xml_url \
+		--prediction-file-list $(EXAMPLE_DATA_ACTUAL_BASE_PATH)/file-list.lst \
+		--output-path .temp/evaluation-results \
+		--sequential
+
+
 dev-distance-matching-profile:
 	$(PYTHON) -m tests.utils.distance_matching_profile
 

--- a/sciencebeam_judge/default_field_names.py
+++ b/sciencebeam_judge/default_field_names.py
@@ -128,7 +128,9 @@ DEFAULT_BODY_BACK_SECTION_FIELDS = get_class_field_name_values(BodyBackSectionFi
 
 DEFAULT_EXCLUDED_FIELDS = {
     BodyFieldNames.SECTION_PARAGRAPHS,
-    BodyBackSectionFieldNames.ALL_SECTION_PARAGRAPHS
+    BodyBackSectionFieldNames.ALL_SECTION_PARAGRAPHS,
+    ReferenceFieldNames.FIRST_REFERENCE_FIELDS,
+    ReferenceFieldNames.REFERENCE_FIELDS
 }
 
 DEFAULT_EXTRACTION_FIELDS_WITHOUT_EXCLUSIONS = (

--- a/sciencebeam_judge/evaluation/scoring_methods.py
+++ b/sciencebeam_judge/evaluation/scoring_methods.py
@@ -1,6 +1,6 @@
 from __future__ import division
 from functools import wraps
-from typing import Callable, List
+from typing import Callable, List, Tuple, Union, T
 
 from difflib import SequenceMatcher
 
@@ -8,6 +8,7 @@ import editdistance
 
 from ..utils.distance_matching import (
     T_Distance_Function,
+    T_Value,
     DistanceMeasure,
     get_length_based_upper_bound_score,
     get_character_count_based_upper_bound_score
@@ -31,21 +32,21 @@ EDIT_DISTANCE_APPROXIMATE_FN_LIST = [
 ]
 
 
-def exact_score(expected: str, actual: str) -> float:
+def exact_score(expected: T_Value, actual: T_Value) -> float:
     return 1 if expected == actual else 0
 
 
-def levenshtein_score(expected: str, actual: str) -> float:
+def levenshtein_score(expected: T_Value, actual: T_Value) -> float:
     if not expected and not actual:
         return 1
     return 1 - (editdistance.eval(expected, actual) / max(len(expected), len(actual)))
 
 
-def ratcliff_obershelp_score(expected: str, actual: str) -> float:
+def ratcliff_obershelp_score(expected: T_Value, actual: T_Value) -> float:
     return SequenceMatcher(None, expected, actual).ratio()
 
 
-def IDENTITY_FN(x):
+def IDENTITY_FN(x: T) -> T:
     return x
 
 
@@ -57,10 +58,10 @@ def wrap_scoring_function_with_preprocessing(
         return scoring_fn
 
     @wraps(scoring_fn)
-    def wrapped(value_1: str, value_2: str) -> float:
-        if value_1:
+    def wrapped(value_1: Union[str, Tuple[str]], value_2: Union[str, Tuple[str]]) -> float:
+        if value_1 and isinstance(value_1, str):
             value_1 = preprocessing_fn(value_1)
-        if value_2:
+        if value_2 and isinstance(value_1, str):
             value_2 = preprocessing_fn(value_2)
         return scoring_fn(value_1, value_2)
     return wrapped

--- a/sciencebeam_judge/evaluation/scoring_types/list.py
+++ b/sciencebeam_judge/evaluation/scoring_types/list.py
@@ -1,12 +1,12 @@
 import logging
 from abc import abstractmethod
-from typing import List, Union, T
+from typing import List, Tuple, Union, T
 
 from six import text_type
 
 from sciencebeam_utils.utils.collection import extend_dict
 
-from ...utils.distance_matching import get_distance_matches, CachedDistanceMeasure
+from ...utils.distance_matching import get_distance_matches
 
 from ..math import safe_mean
 
@@ -45,24 +45,6 @@ def normalize_string_or_list(
 def normalize_list(value, convert_to_lower=False):
     return [
         normalize_string_or_list(x, convert_to_lower=convert_to_lower)
-        for x in value
-    ]
-
-
-def to_string(value: Union[str, List[str]]) -> str:
-    if not value:
-        return ''
-    if isinstance(value, (list, tuple)):
-        return '\n'.join(value)
-    return value
-
-
-def normalize_str_list(
-    value: List[Union[str, List[str]]],
-    convert_to_lower=False
-) -> List[str]:
-    return [
-        normalize_string(to_string(x), convert_to_lower=convert_to_lower)
         for x in value
     ]
 
@@ -170,13 +152,12 @@ def score_value_as_list_using_scoring_method(
 
 
 def score_value_as_unordered_list_using_scoring_method(
-        expected_list, actual_list, scoring_method: ScoringMethod,
-        include_values=False, partial=False):
-    # pylint: disable=too-many-branches, too-many-locals
-
-    expected_str_list = normalize_str_list(expected_list)
-    actual_str_list = normalize_str_list(actual_list)
-
+    expected_list: List[Union[str, Tuple[str]]],
+    actual_list: List[Union[str, Tuple[str]]],
+    scoring_method: ScoringMethod,
+    include_values: bool = False,
+    partial: bool = False
+):
     def to_match_score(score):
         expected_str = list_to_str(expected_list)
         actual_str = list_to_str(actual_list)
@@ -196,12 +177,10 @@ def score_value_as_unordered_list_using_scoring_method(
             )
             return to_match_score(0.0)
 
-    distance_measure = CachedDistanceMeasure(
-        scoring_method.distance_measure
-    )
+    distance_measure = scoring_method.distance_measure
     match_results = get_distance_matches(
-        expected_str_list,
-        actual_str_list,
+        expected_list,
+        actual_list,
         distance_measure=distance_measure,
         threshold=scoring_method.threshold
     )

--- a/tests/evaluation_pipeline_test.py
+++ b/tests/evaluation_pipeline_test.py
@@ -276,10 +276,10 @@ class TestGetScoringTypesByFieldMap:
 class TestParseArgs:
     def test_should_be_able_to_pass_fields(self):
         opt = parse_args(MIN_ARGV + [
-            '--fields=+section_paragraphs,-reference_fields'
+            '--fields=+section_paragraphs,-reference_text'
         ])
         assert 'section_paragraphs' in opt.fields
-        assert 'reference_fields' not in opt.fields
+        assert 'reference_text' not in opt.fields
         assert 'abstract' in opt.fields
 
 

--- a/tests/utils/distance_matching_test.py
+++ b/tests/utils/distance_matching_test.py
@@ -113,15 +113,28 @@ class TestGetDistanceMatches:
             )
         ]
 
-    def test_should_return_multiple_similar_matches(self, distance_measure: DistanceMeasure):
+    def test_should_return_single_similar_tuple_matche(self, distance_measure: DistanceMeasure):
+        tuple_1 = tuple('0123456789')
+        tuple_2 = tuple('012345678X')
         assert get_distance_matches(
-            ['0123456789', 'b', 'c'],
-            ['c', 'b', '012345678X'],
+            [tuple_1],
+            [tuple_2],
             distance_measure
         ) == [
-            DistanceMatch(value_1='0123456789', value_2='012345678X', score=0.9),
-            DistanceMatch(value_1='b', value_2='b', score=1.0),
-            DistanceMatch(value_1='c', value_2='c', score=1.0)
+            DistanceMatch(value_1=tuple_1, value_2=tuple_2, score=0.9)
+        ]
+
+    def test_should_return_multiple_exact_tuple_matches(
+        self, distance_measure: DistanceMeasure
+    ):
+        assert get_distance_matches(
+            [('any', 'a'), ('any', 'b'), ('any', 'c')],
+            [('any', 'c'), ('any', 'b'), ('any', 'a')],
+            distance_measure
+        ) == [
+            DistanceMatch(value_1=('any', 'a'), value_2=('any', 'a'), score=1.0),
+            DistanceMatch(value_1=('any', 'b'), value_2=('any', 'b'), score=1.0),
+            DistanceMatch(value_1=('any', 'c'), value_2=('any', 'c'), score=1.0)
         ]
 
     def test_should_return_missing_items(self, distance_measure: DistanceMeasure):


### PR DESCRIPTION
#345 introduced an improved distance matching that was making evaluation faster for paragraph evaluation as `partial_ulist`.
Unfortunately it was making it slower for fields like `reference_author_surnames` that are evaluated using tuples of strings rather than strings.

This updates the evaluation to be in line with the previous implementation (supporting tuples rather than converting them to string)