### PR TITLE
renamed section_* fields to body_section_*

### DIFF
--- a/evaluation.conf
+++ b/evaluation.conf
@@ -75,8 +75,8 @@ reference_doi = partial_list, partial_set, partial_ulist
 reference_pmid = partial_list, partial_set, partial_ulist
 reference_pmcid = partial_list, partial_set, partial_ulist
 
-section_titles = partial_list, partial_set, partial_ulist
-section_paragraphs = partial_ulist
+body_section_titles = partial_list, partial_set, partial_ulist
+body_section_paragraphs = partial_ulist
 
 back_section_titles = partial_ulist
 back_section_paragraphs = partial_ulist, partial_list

--- a/sciencebeam_judge/default_field_names.py
+++ b/sciencebeam_judge/default_field_names.py
@@ -31,8 +31,8 @@ class AffiliationFieldNames:
 
 
 class BodyFieldNames:
-    SECTION_TITLES = 'section_titles'
-    SECTION_PARAGRAPHS = 'section_paragraphs'
+    BODY_SECTION_TITLES = 'body_section_titles'
+    BODY_SECTION_PARAGRAPHS = 'body_section_paragraphs'
 
     BODY_REFERENCE_CITATION_TEXT = 'body_reference_citation_text'
     BODY_ASSET_CITATION_TEXT = 'body_asset_citation_text'
@@ -127,7 +127,7 @@ DEFAULT_BACK_FIELDS = (
 DEFAULT_BODY_BACK_SECTION_FIELDS = get_class_field_name_values(BodyBackSectionFieldNames)
 
 DEFAULT_EXCLUDED_FIELDS = {
-    BodyFieldNames.SECTION_PARAGRAPHS,
+    BodyFieldNames.BODY_SECTION_PARAGRAPHS,
     BodyBackSectionFieldNames.ALL_SECTION_PARAGRAPHS,
     ReferenceFieldNames.FIRST_REFERENCE_FIELDS,
     ReferenceFieldNames.REFERENCE_FIELDS

--- a/tests/default_xml_mapping/jats_test.py
+++ b/tests/default_xml_mapping/jats_test.py
@@ -391,16 +391,16 @@ class TestJats:
                 xml,
                 xml_mapping=default_xml_mapping,
                 fields=[
-                    'section_titles',
-                    'section_paragraphs',
+                    'body_section_titles',
+                    'body_section_paragraphs',
                     'back_section_titles',
                     'back_section_paragraphs',
                     'all_section_titles',
                     'all_section_paragraphs'
                 ]
             )
-            assert result.get('section_titles') == ['Section Title 1']
-            assert result.get('section_paragraphs') == ['Section Paragraph 1']
+            assert result.get('body_section_titles') == ['Section Title 1']
+            assert result.get('body_section_paragraphs') == ['Section Paragraph 1']
             assert result.get('back_section_titles') == ['Acknowledgement Title', 'Section Title 2']
             assert result.get('back_section_paragraphs') == [
                 'Acknowledgement Paragraph', 'Section Paragraph 2'
@@ -436,14 +436,14 @@ class TestJats:
                 xml,
                 xml_mapping=default_xml_mapping,
                 fields=[
-                    'section_titles',
-                    'section_paragraphs'
+                    'body_section_titles',
+                    'body_section_paragraphs'
                 ]
             )
-            assert result.get('section_titles') == [
+            assert result.get('body_section_titles') == [
                 'Section Title 1', 'Section Title 1.1', 'Section Title 2'
             ]
-            assert result.get('section_paragraphs') == [
+            assert result.get('body_section_paragraphs') == [
                 'Section Paragraph 1a\nSection Paragraph 1b',
                 'Section Paragraph 1.1a\nSection Paragraph 1.1b',
                 'Section Paragraph 2a\nSection Paragraph 2b'
@@ -506,12 +506,12 @@ class TestJats:
                 xml,
                 xml_mapping=default_xml_mapping,
                 fields=[
-                    'section_titles',
+                    'body_section_titles',
                     'back_section_titles',
                     'all_section_titles'
                 ]
             )
-            assert result.get('section_titles') == ['S1. Section Title 1']
+            assert result.get('body_section_titles') == ['S1. Section Title 1']
             assert result.get('back_section_titles') == [
                 'A. Acknowledgement Title', 'S2. Section Title 2'
             ]

--- a/tests/default_xml_mapping/tei_test.py
+++ b/tests/default_xml_mapping/tei_test.py
@@ -314,14 +314,14 @@ class TestTei:
                 xml,
                 xml_mapping=default_xml_mapping,
                 fields=[
-                    'section_titles',
-                    'section_paragraphs',
+                    'body_section_titles',
+                    'body_section_paragraphs',
                     'back_section_titles',
                     'back_section_paragraphs'
                 ]
             )
-            assert result.get('section_titles') == ['Section Title 1']
-            assert result.get('section_paragraphs') == ['Section Paragraph 1']
+            assert result.get('body_section_titles') == ['Section Title 1']
+            assert result.get('body_section_paragraphs') == ['Section Paragraph 1']
             assert result.get('back_section_titles') == ['Acknowledgement Title', 'Section Title 2']
             assert result.get('back_section_paragraphs') == [
                 'Acknowledgement Paragraph', 'Section Paragraph 2'
@@ -349,16 +349,16 @@ class TestTei:
                 xml,
                 xml_mapping=default_xml_mapping,
                 fields=[
-                    'section_titles',
-                    'section_paragraphs'
+                    'body_section_titles',
+                    'body_section_paragraphs'
                 ]
             )
-            assert result.get('section_titles') == [
+            assert result.get('body_section_titles') == [
                 'Section Title 1',
                 'Section Title 1.1',
                 'Section Title 2'
             ]
-            assert result.get('section_paragraphs') == [
+            assert result.get('body_section_paragraphs') == [
                 'Section Paragraph 1a\nSection Paragraph 1b',
                 'Section Paragraph 1.1a\nSection Paragraph 1.1b',
                 'Section Paragraph 2a\nSection Paragraph 2b'
@@ -421,12 +421,12 @@ class TestTei:
                 xml,
                 xml_mapping=default_xml_mapping,
                 fields=[
-                    'section_titles',
+                    'body_section_titles',
                     'back_section_titles',
                     'all_section_titles'
                 ]
             )
-            assert result.get('section_titles') == ['S1. Section Title 1']
+            assert result.get('body_section_titles') == ['S1. Section Title 1']
             assert result.get('back_section_titles') == [
                 'A. Acknowledgement Title', 'S2. Section Title 2'
             ]

--- a/xml-mapping.conf
+++ b/xml-mapping.conf
@@ -74,8 +74,8 @@ reference_pmcid = generic-join-children(back//ref, './/pub-id[@pub-id-type="pmci
 
 keywords = front/article-meta/kwd-group/kwd
 
-section_titles = generic-concat-children(body//sec, '$label', ' ', '$title')
-section_paragraphs =
+body_section_titles = generic-concat-children(body//sec, '$label', ' ', '$title')
+body_section_paragraphs =
   generic-join-children(body//sec, 'p', '
   ')
 
@@ -180,8 +180,8 @@ reference_doi = generic-join-children(text/back//biblStruct, './/idno[@type="DOI
 reference_pmid = generic-join-children(text/back//biblStruct, './/idno[@type="PMID"]', ' ')
 reference_pmcid = generic-join-children(text/back//biblStruct, './/idno[@type="PMCID"]', ' ')
 
-section_titles = generic-join-children((text/body/div | text/body/div//div)/head, './@n | ./text()', ' ')
-section_paragraphs =
+body_section_titles = generic-join-children((text/body/div | text/body/div//div)/head, './@n | ./text()', ' ')
+body_section_paragraphs =
   generic-join-children(text/body/div | text/body/div/div, 'p', '
   ')
 
@@ -190,7 +190,6 @@ back_section_paragraphs =
   generic-join-children(text/back/div[p] | text/back/div//div[p], 'p', '
   ')
 
-# all_section_titles = (text/body/div | text/body/div//div | text/back/div | text/back/div//div)/head
 all_section_titles = generic-join-children((text/body/div | text/body/div//div | text/back/div | text/back/div//div)/head, './@n | ./text()', ' ')
 all_section_paragraphs =
   generic-join-children(text/body/div[p] | text/body/div/div[p] | text/back/div[p] | text/back/div//div[p], 'p', '


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/91

renaming the fields makes it more clear what is being evaluated