### PR TITLE
switched to using unittest.mock

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,4 @@
 flake8==3.9.0
-mock==4.0.3
 nose==1.3.7
 pylint==2.6.2
 pytest==6.2.3

--- a/tests/evaluation_pipeline_test.py
+++ b/tests/evaluation_pipeline_test.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from mock import patch, DEFAULT
+from unittest.mock import patch, DEFAULT
 
 import pytest
 


### PR DESCRIPTION
Therefore do not directly depend on `mock` anymore.
This requires `sciencebeam-utils>=0.1.3` (https://github.com/elifesciences/sciencebeam-utils/pull/147)