### PR TITLE
update evaluation configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The default configuration contains mapping for JATS and TEI.
 The [evaluation.conf](evaluation.conf) allows further evaluation details to be configured.
 For example the *scoring type* defines, how a field should be evaluated as (e.g. `string` or `list`).
 
-An additional [evaluation.yml](evaluation.yml) has the same function but already is more structured configuration.
+An additional [evaluation.yml](evaluation.yml) has the same function as [evaluation.conf](evaluation.conf), but allows for more structured configuration.
 (The content of `evaluation.conf` will likely migrate to `evaluation.yml` in the future)
 
 ## File Lists

--- a/evaluation.yml
+++ b/evaluation.yml
@@ -1,7 +1,15 @@
 custom:
   # Special evaluation of "deleted" (or "lost") text
   fields:
-    - name: all_section_paragraphs_deleted_text
+    - name: body_section_paragraphs_only_deleted_text
+      evaluation_type: deleted_text
+      expected:
+        field_names:
+          - body_section_paragraphs
+      actual:
+        field_names:
+          - body_section_paragraphs
+    - name: body_section_paragraphs_deleted_text
       evaluation_type: deleted_text
       expected:
         field_names:
@@ -9,3 +17,31 @@ custom:
       actual:
         field_names:
           - all_section_paragraphs
+          - all_section_label_titles
+          - table_label_captions
+          - figure_label_captions
+          - abstract
+          - reference_text
+          - title
+    - name: all_section_paragraphs_only_deleted_text
+      evaluation_type: deleted_text
+      expected:
+        field_names:
+          - all_section_paragraphs
+      actual:
+        field_names:
+          - all_section_paragraphs
+    - name: all_section_paragraphs_deleted_text
+      evaluation_type: deleted_text
+      expected:
+        field_names:
+          - all_section_paragraphs
+      actual:
+        field_names:
+          - all_section_paragraphs
+          - all_section_label_titles
+          - table_label_captions
+          - figure_label_captions
+          - abstract
+          - reference_text
+          - title


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/128

This expands on the default deleted text configuration. Configuring the following fields:

- body_section_paragraphs_only_deleted_text (body paragraphs vs body paragraphs only)
- body_section_paragraphs_deleted_text (body paragraphs vs most other text)
- all_section_paragraphs_only_deleted_text (all paragraphs vs all paragraphs only)
- all_section_paragraphs_deleted_text (all paragraphs vs most other text)
