### PR TITLE
fixed cloud mode

### DIFF
--- a/sciencebeam_judge/evaluation_pipeline.py
+++ b/sciencebeam_judge/evaluation_pipeline.py
@@ -103,6 +103,7 @@ def get_logger():
 class MetricCounters:
     FILE_PAIRS = 'file_pairs'
     READ_ERROR = 'read_error'
+    EVALUATION_ERROR = 'evaluation_error'
 
 
 class DataProps:
@@ -405,7 +406,7 @@ def configure_pipeline(p, opt):  # pylint: disable=too-many-locals
     )
     evaluate_file_pairs_transform = (
         beam.Map(evaluate_file_pairs_fn) if not opt.skip_errors
-        else MapOrLog(evaluate_file_pairs_fn)
+        else MapOrLog(evaluate_file_pairs_fn, error_count=MetricCounters.EVALUATION_ERROR)
     )
 
     p_file_pairs = p | beam.Create(file_pairs)

--- a/sciencebeam_judge/evaluation_pipeline.py
+++ b/sciencebeam_judge/evaluation_pipeline.py
@@ -169,7 +169,8 @@ def evaluate_file_pairs(
             evaluation_config=evaluation_config,
             field_names=field_names
         )
-        # Note: we need to register functions again, in case Apache Beam is running this on another worker
+        # Note: we need to register functions again,
+        #   in case Apache Beam is running this on another worker
         register_functions()
         target_xml = parse_xml(
             BytesIO(target_content),

--- a/sciencebeam_judge/evaluation_pipeline.py
+++ b/sciencebeam_judge/evaluation_pipeline.py
@@ -169,6 +169,8 @@ def evaluate_file_pairs(
             evaluation_config=evaluation_config,
             field_names=field_names
         )
+        # Note: we need to register functions again, in case Apache Beam is running this on another worker
+        register_functions()
         target_xml = parse_xml(
             BytesIO(target_content),
             xml_mapping,


### PR DESCRIPTION
related to https://github.com/elifesciences/sciencebeam-issues/issues/135

using `--cloud` to run in Google Dataflow didn't actually work anymore.
This is was due to xpath functions not being registered within the worker.

This also adds a new `evaluation_error` metric counter (where `--skip-errors` is used).