### PR TITLE
fixed section label titles with formatting

### DIFF
--- a/sciencebeam_judge/evaluation_pipeline.py
+++ b/sciencebeam_judge/evaluation_pipeline.py
@@ -377,6 +377,14 @@ def get_evaluation_config(opt: argparse.Namespace) -> EvaluationConfig:
     )
 
 
+def read_file_pairs_log_fn(e, v):
+    LOGGER.warning(
+        'caught exception (ignoring item): %s, target: %s, prediction: %s',
+        e, v[DataProps.TARGET_FILE_URL], v[DataProps.PREDICTION_FILE_URL],
+        exc_info=e
+    )
+
+
 def configure_pipeline(p, opt):  # pylint: disable=too-many-locals
     xml_mapping = parse_xml_mapping(opt.xml_mapping)
     evaluation_config = get_evaluation_config(opt)
@@ -427,13 +435,14 @@ def configure_pipeline(p, opt):  # pylint: disable=too-many-locals
         "ReadFilePairs" >> TransformAndCount(
             MapOrLog(
                 ReadFilePairs,
-                log_fn=lambda e, v: (
-                    get_logger().warning(
-                        'caught exception (ignoring item): %s, target: %s, prediction: %s',
-                        e, v[DataProps.TARGET_FILE_URL], v[DataProps.PREDICTION_FILE_URL],
-                        exc_info=e
-                    )
-                ),
+                log_fn=read_file_pairs_log_fn,
+                # log_fn=lambda e, v: (
+                #     LOGGER.warning(
+                #         'caught exception (ignoring item): %s, target: %s, prediction: %s',
+                #         e, v[DataProps.TARGET_FILE_URL], v[DataProps.PREDICTION_FILE_URL],
+                #         exc_info=e
+                #     )
+                # ),
                 error_count=MetricCounters.READ_ERROR
             ),
             MetricCounters.FILE_PAIRS

--- a/sciencebeam_judge/evaluation_pipeline.py
+++ b/sciencebeam_judge/evaluation_pipeline.py
@@ -377,14 +377,6 @@ def get_evaluation_config(opt: argparse.Namespace) -> EvaluationConfig:
     )
 
 
-def read_file_pairs_log_fn(e, v):
-    LOGGER.warning(
-        'caught exception (ignoring item): %s, target: %s, prediction: %s',
-        e, v[DataProps.TARGET_FILE_URL], v[DataProps.PREDICTION_FILE_URL],
-        exc_info=e
-    )
-
-
 def configure_pipeline(p, opt):  # pylint: disable=too-many-locals
     xml_mapping = parse_xml_mapping(opt.xml_mapping)
     evaluation_config = get_evaluation_config(opt)
@@ -435,14 +427,13 @@ def configure_pipeline(p, opt):  # pylint: disable=too-many-locals
         "ReadFilePairs" >> TransformAndCount(
             MapOrLog(
                 ReadFilePairs,
-                log_fn=read_file_pairs_log_fn,
-                # log_fn=lambda e, v: (
-                #     LOGGER.warning(
-                #         'caught exception (ignoring item): %s, target: %s, prediction: %s',
-                #         e, v[DataProps.TARGET_FILE_URL], v[DataProps.PREDICTION_FILE_URL],
-                #         exc_info=e
-                #     )
-                # ),
+                log_fn=lambda e, v: (
+                    get_logger().warning(
+                        'caught exception (ignoring item): %s, target: %s, prediction: %s',
+                        e, v[DataProps.TARGET_FILE_URL], v[DataProps.PREDICTION_FILE_URL],
+                        exc_info=e
+                    )
+                ),
                 error_count=MetricCounters.READ_ERROR
             ),
             MetricCounters.FILE_PAIRS

--- a/tests/default_xml_mapping/tei_test.py
+++ b/tests/default_xml_mapping/tei_test.py
@@ -454,6 +454,61 @@ class TestTei:
                 'S2. Section Title 2'
             ]
 
+        def test_should_join_label_with_section_title_using_formatting(
+                self, default_xml_mapping):
+            xml = E.TEI(E.text(
+                E.body(E.div(
+                    E.head(E.hi('Section Title 1'), {'n': 'S1.'}),
+                    E.p('Section Paragraph 1')
+                )),
+                E.back(E.div(
+                    {'type': 'acknowledgement'},
+                    E.div(
+                        E.head(E.hi('Acknowledgement Title'), {'n': 'A.'}),
+                        E.p('Acknowledgement Paragraph')
+                    )
+                ), E.div(
+                    E.head(E.hi('Section Title 2'), {'n': 'S2.'}),
+                    E.p('Section Paragraph 2')
+                ))
+            ))
+            result = parse_xml_node(
+                xml,
+                xml_mapping=default_xml_mapping,
+                fields=[
+                    'body_section_labels',
+                    'body_section_titles',
+                    'body_section_label_titles',
+                    'back_section_labels',
+                    'back_section_titles',
+                    'back_section_label_titles',
+                    'all_section_labels',
+                    'all_section_titles',
+                    'all_section_label_titles'
+                ]
+            )
+            assert result.get('body_section_labels') == ['S1.']
+            assert result.get('body_section_titles') == ['Section Title 1']
+            assert result.get('body_section_label_titles') == ['S1. Section Title 1']
+            assert result.get('back_section_labels') == ['A.', 'S2.']
+            assert result.get('back_section_titles') == [
+                'Acknowledgement Title', 'Section Title 2'
+            ]
+            assert result.get('back_section_label_titles') == [
+                'A. Acknowledgement Title', 'S2. Section Title 2'
+            ]
+            assert result.get('all_section_labels') == ['S1.', 'A.', 'S2.']
+            assert result.get('all_section_titles') == [
+                'Section Title 1',
+                'Acknowledgement Title',
+                'Section Title 2'
+            ]
+            assert result.get('all_section_label_titles') == [
+                'S1. Section Title 1',
+                'A. Acknowledgement Title',
+                'S2. Section Title 2'
+            ]
+
     class TestTeiAcknowledgement:
         def test_should_parse_acknowledgement(
                 self, default_xml_mapping):

--- a/xml-mapping.conf
+++ b/xml-mapping.conf
@@ -188,21 +188,21 @@ reference_pmcid = generic-join-children(text/back//biblStruct, './/idno[@type="P
 
 body_section_labels = (text/body/div | text/body/div//div)/head/@n
 body_section_titles = (text/body/div | text/body/div//div)/head
-body_section_label_titles = generic-join-children((text/body/div | text/body/div//div)/head, './@n | ./text()', ' ')
+body_section_label_titles = generic-join-children((text/body/div | text/body/div//div)/head, './@n || .', ' ')
 body_section_paragraphs =
   generic-join-children(text/body/div | text/body/div/div, 'p', '
   ')
 
 back_section_labels = (text/back/div | text/back/div//div)/head/@n
 back_section_titles = (text/back/div | text/back/div//div)/head
-back_section_label_titles = generic-join-children((text/back/div | text/back/div//div)/head, './@n | ./text()', ' ')
+back_section_label_titles = generic-join-children((text/back/div | text/back/div//div)/head, './@n || .', ' ')
 back_section_paragraphs =
   generic-join-children(text/back/div[p] | text/back/div//div[p], 'p', '
   ')
 
 all_section_labels = (text/body/div | text/body/div//div | text/back/div | text/back/div//div)/head/@n
 all_section_titles = (text/body/div | text/body/div//div | text/back/div | text/back/div//div)/head
-all_section_label_titles = generic-join-children((text/body/div | text/body/div//div | text/back/div | text/back/div//div)/head, './@n | ./text()', ' ')
+all_section_label_titles = generic-join-children((text/body/div | text/body/div//div | text/back/div | text/back/div//div)/head, './@n || .', ' ')
 all_section_paragraphs =
   generic-join-children(text/body/div[p] | text/body/div/div[p] | text/back/div[p] | text/back/div//div[p], 'p', '
   ')

--- a/xml-mapping.conf
+++ b/xml-mapping.conf
@@ -195,6 +195,7 @@ body_section_paragraphs =
 
 back_section_labels = (text/back/div | text/back/div//div)/head/@n
 back_section_titles = (text/back/div | text/back/div//div)/head
+# Note: using `||` to ensure order of section label, then title (when joining the text)
 back_section_label_titles = generic-join-children((text/back/div | text/back/div//div)/head, './@n || .', ' ')
 back_section_paragraphs =
   generic-join-children(text/back/div[p] | text/back/div//div[p], 'p', '


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/163

The previous xpath mapping used `text()` to ensure the order when joining the section label with the title.
That however didn't work when the section titles contains formatting (child elements).

Changed `generic-join-children` to split the passed in `xpath` on `||`. That way elements are joined in that order.